### PR TITLE
Allows multiple db tags and catch error

### DIFF
--- a/rpm/python-pymongor.spec
+++ b/rpm/python-pymongor.spec
@@ -5,7 +5,7 @@
 %define version 0.3
 %define unmangled_version 0.3
 %define unmangled_version 0.3
-%define release 10
+%define release 12
 Summary: A utility to curate mongo databases
 Name: %{name}
 Version: %{version}


### PR DESCRIPTION
Use the $in rather than $all.  Now the client can send a list of db_tags
rather than a single tag.  No functionality gained here since the same
work could have been done via configuration anyway, but this is more
intuitive.

Half way handles an error that presents if you configure an edge node to
also be the central server. 

You still shouldn't do that though.

(•_•) 
( •_•)>⌐■-■ 
(⌐■_■)
